### PR TITLE
fix: upgrade actions for GitHub Pages upload

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -42,4 +42,4 @@ jobs:
           path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: '.'


### PR DESCRIPTION
Ref:
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/